### PR TITLE
[Fix #3] Use deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,1 @@
+{:deps {org.clojure/clojure {:mvn/version "1.9.0"}}}


### PR DESCRIPTION
Decided against using `lein-tools-deps` as that forces a `brew install clojure` 